### PR TITLE
feat: option to invalidate keys on biometric change

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const keySpec: KeySpec = {
   alias: keyAlias,
   algorithm: 'EC', // or 'RSA'
   size: 256, // or 2048 for 'RSA'
+  invalidateOnBiometricEnrollment: true, // optional, default to false
 };
 
 const publicKey: PublicKey = await Signature.generateKeys(alias);

--- a/android/src/main/java/expo/module/signature/SignatureModule.kt
+++ b/android/src/main/java/expo/module/signature/SignatureModule.kt
@@ -100,7 +100,7 @@ class SignatureModule : Module() {
                 setIsStrongBoxBacked(true)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                setInvalidatedByBiometricEnrollment(false)
+                setInvalidatedByBiometricEnrollment(keySpec.invalidateOnBiometricEnrollment)
             }
             build()
         }

--- a/android/src/main/java/expo/module/signature/models/KeySpec.kt
+++ b/android/src/main/java/expo/module/signature/models/KeySpec.kt
@@ -7,5 +7,6 @@ data class KeySpec(
     @Field val algorithm: SignatureAlgorithm = SignatureAlgorithm.EC,
     @Field val alias: String = "default_expo_signature_alias",
     @Field val size: Int = 256,
+    @Field val invalidateOnBiometricEnrollment: Boolean = false,
 ): Record
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -27,6 +27,7 @@ export default function App() {
       alias: keyTag,
       algorithm: 'RSA',
       size: 2048,
+      invalidateOnBiometricEnrollment: true
     });
     setPublicKey(publicKey);
   }, []);

--- a/ios/Module/SignatureModule.swift
+++ b/ios/Module/SignatureModule.swift
@@ -31,10 +31,11 @@ public class SignatureModule: Module {
             return publicKey
         }
         
+        let biometryFlag: SecAccessControlCreateFlags = keySpec.invalidateOnBiometricEnrollment ? .biometryCurrentSet : .biometryAny
         guard let access = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
             kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            [.privateKeyUsage, .biometryAny],
+            [.privateKeyUsage, biometryFlag],
             &error
         ) else {
             throw error!.takeRetainedValue()

--- a/ios/Module/models/KeySpec.swift
+++ b/ios/Module/models/KeySpec.swift
@@ -11,6 +11,7 @@ struct KeySpec: Record {
     @Field var algorithm: SignatureAlgorithm = .EC
     @Field var alias: String = "default_expo_signature_alias"
     @Field var size: Int = 256
+    @Field var invalidateOnBiometricEnrollment: Bool = false
 }
 
 extension KeySpec {

--- a/src/SignatureModule.types.ts
+++ b/src/SignatureModule.types.ts
@@ -4,6 +4,7 @@ export type KeySpec<Algorithm extends SignatureAlgorithm = SignatureAlgorithm> =
   algorithm: Algorithm;
   alias: string;
   size: number;
+  invalidateOnBiometricEnrollment?: boolean;
 };
 
 export type ECPublicKey = {


### PR DESCRIPTION
## Describe your changes

Created keys can be invalidated when a user adds new biometric credentials to the device.
This new security option, passed during the key creation, is disabled by default.

## How to test

- create a key pair with `invalidateOnBiometricEnrollment` prop set to `true`
- add a new biometric credentials to the device
- try to sign data with the previous created key
- creation shouldn't success

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have made corresponding changes to the documentation
